### PR TITLE
Extendable HTML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,26 @@ Array of Strings.  Optional
 
 Used in conjunction with global showTags option to add additional information to the right of each node; using [Bootstrap Badges](http://getbootstrap.com/components/#badges) 
 
-### Extendible
+## Extendible
 
 You can extend the node object by adding any number of additional key value pairs that you require for your application.  Remember this is the object which will be passed around during selection events.
+
+If you need some key/value pair to be added to node's HTML element, add `data-` prefix to the key:
+
+```javascript
+{
+  text: "file name",
+  'data-path': "path to file"
+}
+```
+
+will render like:
+
+```html
+<li ... data-path="path to file">
+  file name
+</li>
+```
 
 
 

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -258,6 +258,13 @@
 					.addClass((node === self.selectedNode) ? 'node-selected' : '')
 					.attr('data-nodeid', node.nodeId)
 					.attr('style', self._buildStyleOverride(node));
+				
+				// add attrs defined in JSON
+				// but only ones starting with data-
+				$.each(node._data, function(k, v) {
+					if (k.match(/^data\-/))
+						treeItem.attr(k, v);
+				});
 
 				// Add indent/spacer to mimic tree structure
 				for (var i = 0; i < (level - 1); i++) {


### PR DESCRIPTION
Having extendable nodes is great, let's also have extendable HTML elements.
Actually i'm setting `path` inside my JSON source so when a node selected i know path to file and do various operations.

But what when we need to read that data on another events, e.g. on context menu?

I guess lets add that data to the HTML as well.
And to avoid clutter, let's add only attrs starting with `data-`.
Makes sense?
