### PR TITLE
Selectable node option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ String.  Optional
 
 Used in conjunction with global enableLinks option to specify anchor tag URL on a given node.
 
+### selectable
+Boolean.  Default: true
+
+Whether of not a node is selectable in the tree. False indicates the node should act as an expansion heading and will not fire selection events.
+
 ### tags
 Array of Strings.  Optional
 

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -138,7 +138,12 @@
 				this._render();
 			}
 			else if (node) {
-				this._setSelectedNode(node);
+				if (this._isSelectable(node)) {
+					this._setSelectedNode(node);
+				} else {
+					this._toggleNodes(node);
+					this._render();
+				}
 			}
 		},
 
@@ -216,6 +221,11 @@
 				node.nodes = node._nodes;
 				delete node._nodes;
 			}
+		},
+
+		// Returns true if the node is selectable in the tree
+		_isSelectable: function (node) {
+			return node.selectable !== false;
 		},
 
 		_render: function() {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -215,7 +215,7 @@
 		el = $('.list-group-item:first');
 		ok((el.attr('class').split(' ').indexOf('node-selected') !== -1), 'Node is correctly selected : class "node-selected" added');
 		ok(($('.node-selected').length === 1), 'There is only one selected node');
-		ok(cbWorked, 'onNodeSelected function was calledted');
+		ok(cbWorked, 'onNodeSelected function was called');
 		ok(onWorked, 'nodeSelected was fired');
 	});
 
@@ -245,6 +245,58 @@
 		ok(($('.node-selected').length === 0), 'There are no selected nodes');
 		ok(!cbWorked, 'onNodeSelected was not called');
 		ok(!onWorked, 'nodeSelected was not fired');
+	});
+
+	test('Clicking a non-selectable, colllapsed node expands the node', function () {
+		var testData = $.extend(true, {}, data);
+		testData[0].selectable = false;
+
+		var cbCalled, onCalled = false;
+		init({
+			levels: 1,
+			data: testData,
+			onNodeSelected: function(/*event, date*/) {
+				cbCalled = true;
+			}
+		})
+		.on('nodeSelected', function(/*event, date*/) {
+			onCalled = true;
+		});
+
+		var nodeCount = $('.list-group-item').length;
+		var el = $('.list-group-item:first');
+		el.trigger('click');
+		el = $('.list-group-item:first');
+		ok(!el.hasClass('node-selected'), 'Node should not be selected');
+		ok(!cbCalled, 'onNodeSelected function should not be called');
+		ok(!onCalled, 'nodeSelected should not fire');
+		ok(($('.list-group-item').length > nodeCount), 'Number of nodes are increased, so node must have expanded');
+	});
+
+	test('Clicking a non-selectable, expanded node collapses the node', function () {
+		var testData = $.extend(true, {}, data);
+		testData[0].selectable = false;
+
+		var cbCalled, onCalled = false;
+		init({
+			levels: 2,
+			data: testData,
+			onNodeSelected: function(/*event, date*/) {
+				cbCalled = true;
+			}
+		})
+		.on('nodeSelected', function(/*event, date*/) {
+			onCalled = true;
+		});
+
+		var nodeCount = $('.list-group-item').length;
+		var el = $('.list-group-item:first');
+		el.trigger('click');
+		el = $('.list-group-item:first');
+		ok(!el.hasClass('node-selected'), 'Node should not be selected');
+		ok(!cbCalled, 'onNodeSelected function should not be called');
+		ok(!onCalled, 'nodeSelected should not fire');
+		ok(($('.list-group-item').length < nodeCount), 'Number of nodes has decreased, so node must have collapsed');
 	});
 
 }());


### PR DESCRIPTION
This change is similar to @chawkinsuf's, although a little more flexible in the designation of which nodes can be selected. Non-selectable nodes act as expansion/contraction headers and do not fire events. Nodes that do not specify a `selectable` property retain existing (i.e., they are selectable) behavior for backward-compatibility.
