### PR TITLE
singleClickToggle config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ String.  Optional
 
 Used in conjunction with global enableLinks option to specify anchor tag URL on a given node.
 
+### singleClickToggle
+Boolean. Optional
+
+When true, nodes will automatically expand when clicked, in addition to becoming selected.
+
 ### tags
 Array of Strings.  Optional
 

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -61,6 +61,8 @@
 		showBorder: true,
 		showTags: false,
 
+		singleClickToggle: false,
+
 		// Event handler for when a node is selected
 		onNodeSelected: undefined
 	};
@@ -139,6 +141,11 @@
 			}
 			else if (node) {
 				this._setSelectedNode(node);
+
+				if (this.options.singleClickToggle === true) {
+					this._toggleNodes(node);
+					this._render();
+				}
 			}
 		},
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -247,4 +247,34 @@
 		ok(!onWorked, 'nodeSelected was not fired');
 	});
 
+	test('Clicking a collapsed node expands the node when singleClickToggle true', function () {
+		init({
+			levels: 1,
+			data: data,
+			singleClickToggle: true
+		});
+
+		var nodeCount = $('.list-group-item').length;
+		var el = $('.list-group-item:first');
+		el.trigger('click');
+		el = $('.list-group-item:first');
+		ok(el.hasClass('node-selected'), 'Node should be selected');
+		ok(($('.list-group-item').length > nodeCount), 'Number of nodes has incrased, so node must have expanded');
+	});
+
+	test('Clicking an expanded node collapses the node when singleClickToggle true', function () {
+		init({
+			levels: 2,
+			data: data,
+			singleClickToggle: true
+		});
+
+		var nodeCount = $('.list-group-item').length;
+		var el = $('.list-group-item:first');
+		el.trigger('click');
+		el = $('.list-group-item:first');
+		ok(el.hasClass('node-selected'), 'Node should be selected');
+		ok(($('.list-group-item').length < nodeCount), 'Number of nodes has decreased, so node must have collapsed');
+	});
+
 }());


### PR DESCRIPTION
Adds a configuration option to allow nodes to expand/collapse (toggle) on a single click of their text. This simplifies interactions on mobile devices. Default config value is false, maintaining backwards compatibility.
