### PR TITLE
Add emptyIcon config

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ String, [any legal color value](http://www.w3schools.com/cssref/css_colors_legal
 
 Sets the default foreground color used by all nodes, except when overridden on a per node basis in data.
 
+### emptyIcon
+String, class name(s).  Default: "glyphicon" as defined by [Bootstrap Glyphicons](http://getbootstrap.com/components/#glyphicons)
+
+Sets the icon to be used on a tree node with no child nodes.
+
 ### enableLinks
 Boolean.  Default: false
 

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -47,6 +47,7 @@
 
 		expandIcon: 'glyphicon glyphicon-plus',
 		collapseIcon: 'glyphicon glyphicon-minus',
+		emptyIcon: 'glyphicon',
 		nodeIcon: 'glyphicon glyphicon-stop',
 
 		color: undefined, // '#000000',
@@ -286,7 +287,7 @@
 					treeItem
 						.append($(self._template.iconWrapper)
 							.append($(self._template.icon)
-								.addClass('glyphicon'))
+								.addClass(self.options.emptyIcon))
 						);
 				}
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -90,6 +90,7 @@
 		equal(options.levels, 2, 'levels defaults ok');
 		equal(options.expandIcon, 'glyphicon glyphicon-plus', 'expandIcon defaults ok');
 		equal(options.collapseIcon, 'glyphicon glyphicon-minus', 'collapseIcon defaults ok');
+		equal(options.emptyIcon, 'glyphicon', 'emptyIcon defaults ok');
 		equal(options.nodeIcon, 'glyphicon glyphicon-stop', 'nodeIcon defaults ok');
 		equal(options.color, undefined, 'color defaults ok');
 		equal(options.backColor, undefined, 'backColor defaults ok');
@@ -108,6 +109,7 @@
 			levels: 99,
 			expandIcon: 'glyphicon glyphicon-expand',
 			collapseIcon: 'glyphicon glyphicon-collapse',
+			emptyIcon: 'glyphicon',
 			nodeIcon: 'glyphicon glyphicon-node',
 			color: 'yellow',
 			backColor: 'purple',
@@ -127,6 +129,7 @@
 		equal(options.levels, 99, 'levels set ok');
 		equal(options.expandIcon, 'glyphicon glyphicon-expand', 'expandIcon set ok');
 		equal(options.collapseIcon, 'glyphicon glyphicon-collapse', 'collapseIcon set ok');
+		equal(options.emptyIcon, 'glyphicon', 'emptyIcon set ok');
 		equal(options.nodeIcon, 'glyphicon glyphicon-node', 'nodeIcon set ok');
 		equal(options.color, 'yellow', 'color set ok');
 		equal(options.backColor, 'purple', 'backColor set ok');


### PR DESCRIPTION
This allows customization of the placeholder icon for nodes that have no child nodes. 
