### PR TITLE
onNodeChange and onNodeChanging events

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,35 @@ and using jQuery .on method
 		
 
 
+### nodeChange
+Fired when a user selects/deselects a node. `node` argument can be the current node being selected or `null` in case of deselection.
+
+Example using options callback handler:
+
+	var options = {
+		onNodeChange: function(event, node) {
+			// Your logic goes here
+		}
+	}
+	$('#tree').treeview(options);
+
+and using jQuery .on method
+
+	$('#tree').on('nodeChange', function(event, node) {
+		// Your logic goes here
+	});
+		
+
+### nodeChanging
+Fired when a user attempts to change the current selected node. `oldNode` is the current selected node, `newNode` is the node being changed to, `accept` is a function which can be called with a boolean callback to accept or deny the change
+
+Example using options callback handler:
+
+	var options = {
+		onNodeChanging: function(oldNode, newNode, accept) {
+			// Your logic goes here
+		}
+	}
 
 ## Copyright and Licensing
 Copyright 2013 Jonathan Miles

--- a/public/index.html
+++ b/public/index.html
@@ -230,6 +230,12 @@
 
 
         $('#treeview1').treeview({
+          onNodeChange: function(event, node){
+            console.log(node);
+          },
+          onNodeChanging: function(currentNode, newNode, change){
+              change(confirm('Change node?'));
+          },
           data: defaultData
         });
 

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -195,7 +195,7 @@
 
             // if user subscribed to nodeChanging event, dispatch it and wait for results
             // else call onChange/onNodeSelected events immediately
-            if(typeof this.options.onNodeChanging == 'function'){
+            if((typeof this.options.onNodeChanging == 'function') && node != this.selectedNode){
                 var self = this;
                 this.options.onNodeChanging(this.selectedNode, node, function(change){
                     if(change){

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -172,7 +172,7 @@
         },
 
 
-        // Changes the selected node to the specified one without triggering relying on the onChanging event
+        // Changes the selected node to the specified one without relying on the onChanging event
         _setSelectedNodeInternal: function(node){
             var target;
 

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -197,7 +197,7 @@
             // else call onChange/onNodeSelected events immediately
             if(typeof this.options.onNodeChanging == 'function'){
                 var self = this;
-                this.options.onNodeChanging(null, function(change){
+                this.options.onNodeChanging(this.selectedNode, node, function(change){
                     if(change){
                         self._setSelectedNodeInternal(node);
                     }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -247,4 +247,99 @@
 		ok(!onWorked, 'nodeSelected was not fired');
 	});
 
+    test('Selecting a node (onNodeChange)', function(){
+        var nodeParam = null;
+        init({
+            data: data,
+            onNodeChange: function(event, node){
+                nodeParam = node;
+            }
+        });
+
+        var el = $('.list-group-item:first');
+        el.trigger('click');
+        ok(($('.node-selected').length === 1), 'There is only one selected node');
+        ok(nodeParam, 'onNodeChange was called');
+    });
+
+    test('Selecting and deselecting a node (onNodeChange)', function(){
+        var nodeParam = null;
+        init({
+            data: data,
+            onNodeChange: function(event, node){
+                nodeParam = node;
+            }
+        });
+
+        $('.list-group-item:first').trigger('click');
+        ok(nodeParam, 'onNodeChange was called');
+
+        // current node is deselected and the arg should be null
+        $('.list-group-item:first').trigger('click');
+        ok(nodeParam == null, 'onNodeChange was called');
+    });
+
+    test('onNodeChanging event (accept change)', function(){
+        var cbWorked = false;
+        var firstNodeA;
+        var firstNodeB;
+        var secondNode;
+
+        var tsChanging, tsChange;
+
+        init({
+            data: data,
+            onNodeChange: function(event, node){
+                tsChange = + new Date();
+                if(!firstNodeB){
+                    firstNodeB = node;
+                }
+            },
+            onNodeChanging: function(oldNode, newNode, accept){
+                tsChanging = +new Date();
+
+                //console.log('changing', oldNode, newNode, typeof accept);
+                firstNodeA = oldNode;
+                secondNode = newNode;
+                accept(true);
+            }
+        });
+
+        // select the first node.
+        $('.list-group-item:first').trigger('click');
+
+        ok(!firstNodeA.text, 'Empty "old" node');
+        ok((typeof tsChange == 'number') && (typeof tsChanging == 'number'), "Both events fired");
+        ok(tsChange >= tsChanging, "onNodeChanging is called before onNodeChange");
+
+        // switch to the second one
+        $('.list-group-item:eq(1)').trigger('click');
+        ok(firstNodeA.nodeId === firstNodeB.nodeId, 'Correct node reference(copy)');
+        ok(firstNodeA.nodeId !== secondNode.nodeId, 'Node sucessfuly changed');
+    });
+
+    test('onNodeChanging event (deny change)', function(){
+        var cbWorked = true;
+        var selectedNode = null;
+
+        init({
+            data: data,
+            onNodeChange: function(){
+                cbWorked = false;
+            },
+            onNodeChanging: function(oldNode, newNode, accept){
+                accept(false);
+            }
+        });
+
+        // select the first node.
+        var el = $('.list-group-item:first');
+        el.trigger('click');
+        ok(cbWorked, 'onNodeChange not fired');
+
+        // attempt to switch to the second one, selection will still not change
+        $('.list-group-item:eq(1)').trigger('click');
+        ok(cbWorked, 'onNodeChange still not fired');
+    });
+
 }());


### PR DESCRIPTION
Adds `onNodeChange` and `onNodeChanging` events

`onNodeChange` is intended to be a replacement for `onNodeSelected` due to the fact that it also handles deselection by passing `null` to the `node` argument. However both are kept for compatibility.

`onNodeChanging` is triggered when the user wants to change nodes. It has 3 arguments: `currentNode`, `newNode` and a `change` function which will serve as a callback to allow for async tasks and to trigger the change or not. The function accepts a boolean parameter which if set to true will finalize the change.

Tell me what you think on the proposed changes.