### PR TITLE
Disable hyperlink generation when node.href is empty

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -305,8 +305,8 @@
 					);
 
 				// Add text
-				if (self.options.enableLinks) {
-					// Add hyperlink
+				if (self.options.enableLinks && node.href && node.href != null && node.href != "") {
+					// Add hyperlink if node.href is not empty
 					treeItem
 						.append($(self._template.link)
 							.attr('href', node.href)


### PR DESCRIPTION
At line 308, adding more conditions when choosing for create a hyperlink element instead a text node:
... && node.href && node.href != null && node.href != "") {
avoids to generate hyperlink elements when it is not necessary, that I think is the expected behavior for this case.