### PR TITLE
Added method collapseChildren(identifier)

### DIFF
--- a/public/js/bootstrap-treeview.js
+++ b/public/js/bootstrap-treeview.js
@@ -309,11 +309,21 @@
 
 			// Collapse a node
 			node.state.expanded = false;
+			if (this.options.collapseChildrenOnCollapse) this.collapseChildren(node);
 			if (!silent) {
 				this.$element.trigger('nodeCollapsed', $.extend(true, {}, node));
 			}
 		}
 	};
+
+	Tree.prototype.collapseChildren = function (identifier) {
+		var node = this.identifyNode(identifier),
+			that = this;
+		if (node.nodes) $.each(node.nodes, function (index, childNode) {
+			childNode.state.expanded = false;
+			that.collapseChildren(childNode);
+		});
+	}
 
 	Tree.prototype.toggleSelectedState = function (node, silent) {
 		if (!node) { return; }


### PR DESCRIPTION
When I collapse a node, I expected all its children to be collapsed.  

So if you now set option `collapseChildrenOnCollapse: true`, this will happen:

The method `setNodeExpandedState(false)` calls a new recursive method `collapseChildren(identifier)` that collapses all children and sub-children of ìdentifier.