### PR TITLE
Check if there are nodes before adding expandIcon

### DIFF
--- a/public/js/bootstrap-treeview.js
+++ b/public/js/bootstrap-treeview.js
@@ -527,7 +527,7 @@
 
 			// Add expand, collapse or empty spacer icons
 			var classList = [];
-			if (node.nodes) {
+			if (node.nodes && node.nodes.length > 0) {
 				classList.push('expand-icon');
 				if (node.state.expanded) {
 					classList.push(_this.options.collapseIcon);


### PR DESCRIPTION
If you provide data with an empty nodes like `nodes: [ ]` the tree will show an expand icon.
Fixed this issue.
