### PR TITLE
Add customize option to free add more html tag to list item

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -337,6 +337,8 @@
 			
 			if (node.selectable) {
 				this.toggleSelectedState(node, _default.options);
+			} else if (this.options.customize) {
+				// Do nothing
 			} else {
 				this.toggleExpandedState(node, _default.options);
 			}
@@ -604,6 +606,11 @@
 							.append(tag)
 						);
 				});
+			}
+
+			// Add customized content
+			if (_this.options.customize) {
+				_this.options.customize(treeItem, node);
 			}
 
 			// Add item to the tree


### PR DESCRIPTION
![9e0d0d66644742d7ed918efe42f2e646](https://cloud.githubusercontent.com/assets/358186/10930596/12b78124-8303-11e5-8a59-e71f0cf6a6b7.png)

For example, I want to add button into listview.
I can use customize options like below.

```
    $("#tree").treeview({
      data: tree_data,
      selectable: false,
      levels: 4,
      showTags: true,
      customize: function(treeItem, node){
        // Add button
          html = "<a class='btn btn-default'> \
            <i class='glyphicon glyphicon-plus'></i>\
          </a>"
          tag = $(html);
          tag.attr("data-nodeid", node.nodeId);
          treeItem.append(tag);
      }
```

@jonmiles 
