### PR TITLE
Multi-line indent error

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -671,10 +671,12 @@
 			node.$el.empty();
 		}
 
-		// Add indent/spacer to mimic tree structure
-		for (var i = 0; i < (node.level - 1); i++) {
-			node.$el.append(this._template.indent);
-		}
+		 // Add indent/spacer to mimic tree structure
+	        var spaceCal = 15;
+	        for (var i = 0; i < (level - 1); i++) {
+	            spaceCal += 20;
+	        }
+            	treeItem.css("padding-left", spaceCal + 'px');
 
 		// Add expand / collapse or empty spacer icons
 		node.$el


### PR DESCRIPTION
Changed indent method.

Used margin-left CSS instead of using <span> as intend child anchor tags.

This will solve multi-line intent problems, as well as minimal generated HTML.
