### PR TITLE
Adding condition for nodes who don't have "href"

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -582,7 +582,7 @@
 			}
 
 			// Add text
-			if (_this.options.enableLinks) {
+			if ((_this.options.enableLinks) && (node.href != undefined)) {
 				// Add hyperlink
 				treeItem
 					.append($(_this.template.link)


### PR DESCRIPTION
When the option 'enableLinks' is true all nodes was receiving the attribute 'href' even if there wasn't none in the node declaration in the data. Now only when the node has the 'href' defined and 'enableLinks' is true the output will have the 'href' attribute
