### PR TITLE
FIx license syntax for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,7 @@
   "bugs": {
     "url": "https://github.com/jonmiles/bootstrap-treeview/issues"
   },
-  "licenses": [
-    {
-      "type": "Apache",
-      "url": "https://github.com/jonmiles/bootstrap-treeview/blob/master/LICENSE"
-    }
-  ],
+  "license": "Apache-2.0",
   "main": [
     "dist/bootstrap-treeview.min.js",
     "dist/bootstrap-treeview.min.css"


### PR DESCRIPTION
To be accepted by webjars/bintray. See also: https://docs.npmjs.com/files/package.json

```
Failed!
No valid licenses found. Detected licenses: Apache
The acceptable licenses on BinTray are at: https://bintray.com/docs/api/#_footnote_1
License detection first uses the package metadata (e.g. package.json or bower.json) and falls back to looking for a LICENSE, LICENSE.txt, or LICENSE.md file in the master branch of the GitHub repo.
Since these methods failed to detect a valid license you will need to work with the upstream project to add discoverable license metadata to a release or to the GitHub repo.

If you feel you have reached this failure in error, please file an issue: https://github.com/webjars/webjars/issues

Created NPM WebJar
Fetched NPM tgz
Generated POM
Converted dependencies to Maven
Got NPM info
Determined Artifact Name: bootstrap-treeview
Starting Deploy
```
