### PR TITLE
express, ejs and phantomjs moved to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,19 +31,17 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "dependencies": {
-    "express": "3.4.x",
-    "ejs": "2.2.x",
-    "phantomjs": "1.9.x"
-  },
   "devDependencies": {
     "bower": "1.3.x",
+    "ejs": "2.2.x",
+    "express": "3.4.x",
     "grunt": "0.4.x",
     "grunt-contrib-uglify": "0.7.x",
     "grunt-contrib-cssmin": "0.12.x",
     "grunt-contrib-qunit": "0.5.x",
     "grunt-contrib-watch": "0.6.x",
-    "grunt-contrib-copy": "0.7.x"
+    "grunt-contrib-copy": "0.7.x",
+    "phantomjs": "1.9.x"
   },
   "keywords": [
     "twitter",


### PR DESCRIPTION
Having express, ejs and phantomjs in dependencies makes troubles in projects managing their deps using npm.
