### PR TITLE
Custom data attribute into each node

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -520,7 +520,14 @@
 				.attr('data-nodeid', node.nodeId)
 				.attr('style', _this.buildStyleOverride(node));
 
-			// Add indent/spacer to mimic tree structure
+			// Added data-custom attribute into <li> elements
+                        // to be used for custom events by adding/remove item
+                        if(node.custom){
+                            treeItem
+                                    .attr('data-custom', node.custom);
+                        }
+
+                        // Add indent/spacer to mimic tree structure
 			for (var i = 0; i < (level - 1); i++) {
 				treeItem.append(_this.template.indent);
 			}


### PR DESCRIPTION
I have added a custom data attribute to be used to store any type of data related with a node element to be used for our own actions, like read it via AJAX and do some actions.

It is only added if you add it into the JSON data.

The JSON has to be something like this: 

`var tree = [
            {
                text: "Parent 1",
                custom: 233,
                nodes: [
                    {
                        text: "Child 1",
                        custom: 235,
                        nodes: [
                            {
                                text: "Grandchild 1"
                                custom: 236,
                            },
                            {
                                text: "Grandchild 2"
                               custom: 239,
                            }
                        ]
                    },
        ];`
