### PR TITLE
moved dependencies to the right place

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,18 +32,20 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "express": "3.4.x",
-    "ejs": "2.2.x",
-    "phantomjs": "1.9.x"
+    "bootstrap": ">= 3.0.0",
+    "jquery": ">= 1.9.0"
   },
   "devDependencies": {
     "bower": "1.3.x",
+    "ejs": "2.2.x",
+    "express": "3.4.x",
     "grunt": "0.4.x",
     "grunt-contrib-uglify": "0.7.x",
     "grunt-contrib-cssmin": "0.12.x",
     "grunt-contrib-qunit": "0.5.x",
     "grunt-contrib-watch": "0.6.x",
-    "grunt-contrib-copy": "0.7.x"
+    "grunt-contrib-copy": "0.7.x",
+    "phantomjs": "1.9.x"
   },
   "keywords": [
     "twitter",


### PR DESCRIPTION
To use npm instead of bower we need angular in the dependencies to use something similar to npms `main-bower-files` module (e.g. a new module named `main-npm-files`).
