### PR TITLE
Added bootstrap labels

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -600,7 +600,7 @@
 			// Add labels as labels
 			if (_this.options.showLabels && node.labels) {
 				$.each(node.labels, function addLabel(id, label) {
-          treeItem.append($(_this.template.label).addClass("label-" + label.class).append(label.text));
+					treeItem.append($(_this.template.label).addClass("label-" + label.class).append(label.text));
 				});
 			}
 
@@ -701,7 +701,7 @@
 		icon: '<span class="icon"></span>',
 		link: '<a href="#" style="color:inherit;"></a>',
 		badge: '<span class="badge"></span>',
-    label: '<span class="label"></span>',
+		label: '<span class="label"></span>',
 	};
 
 	Tree.prototype.css = '.treeview .list-group-item{cursor:pointer}.treeview span.indent{margin-left:10px;margin-right:10px}.treeview span.icon{width:12px;margin-right:5px}.treeview .node-disabled{color:silver;cursor:not-allowed}'

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -57,6 +57,7 @@
 		showIcon: true,
 		showCheckbox: false,
 		showTags: false,
+		showLabels: false,
 		multiSelect: false,
 
 		// Event handlers
@@ -596,6 +597,13 @@
 					.append(node.text);
 			}
 
+			// Add labels as labels
+			if (_this.options.showLabels && node.labels) {
+				$.each(node.labels, function addLabel(id, label) {
+          treeItem.append($(_this.template.label).addClass("label-" + label.class).append(label.text));
+				});
+			}
+
 			// Add tags as badges
 			if (_this.options.showTags && node.tags) {
 				$.each(node.tags, function addTag(id, tag) {
@@ -692,7 +700,8 @@
 		indent: '<span class="indent"></span>',
 		icon: '<span class="icon"></span>',
 		link: '<a href="#" style="color:inherit;"></a>',
-		badge: '<span class="badge"></span>'
+		badge: '<span class="badge"></span>',
+    label: '<span class="label"></span>',
 	};
 
 	Tree.prototype.css = '.treeview .list-group-item{cursor:pointer}.treeview span.indent{margin-left:10px;margin-right:10px}.treeview span.icon{width:12px;margin-right:5px}.treeview .node-disabled{color:silver;cursor:not-allowed}'


### PR DESCRIPTION
Added a way to display bootstrap labels.

Add `labels: [{text: "Label text", class: "Label class from {default, primary, success, info, warning, danger}, …]"` to a node to add labels with the desired `label-`class next to nodes.  
Set option `showLabels: true` to enable them, default is `false`.
