### PR TITLE
Update to only show nodeIcon for leaf nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,8 @@ $('#tree').on('nodeSelected', function(event, data) {
 
 ### List of Events
 
+`findNodeIdByCustomIdComplete(event, {nodeId: <id>, customId: <custom id>})` - a node was found
+
 `nodeChecked (event, node)`  - A node is checked.
 
 `nodeCollapsed (event, node)`  - A node is collapsed.

--- a/README.md
+++ b/README.md
@@ -513,6 +513,15 @@ $('#tree').treeview('expandNode', [ nodeId, { levels: 2, silent: true } ]);
 
 Triggers `nodeExpanded` event; pass silent to suppress events.
 
+#### findNodeIdByCustomId(customId)
+
+Find the `nodeId` of a node in the tree whose `customId` matches the given customId. If no match can be
+found then `undefined` is returned.
+
+```javascript
+$('#tree').treeview('findNodeIdByCustomId', 3)
+```
+
 #### getCollapsed()
 
 Returns an array of collapsed nodes e.g. state.expanded = false.

--- a/README.md
+++ b/README.md
@@ -527,8 +527,9 @@ Triggers `findNodeIdByCustomIdComplete` event.
 #### findNodesByCustomIds(customIds)
 
 Find nodes in the tree whose `customId` matches those given in `customIds`. The return value is
-an object with two properties:
+an object with three properties:
   * `customIds` - the customIds given to the function
+  * `nodeIds` - the tree node ids of the nodes that matched
   * `nodesMap` - an object that maps the customId to an array of matching tree nodes (an array is
      used because its possible one custom id is represented multiple times in the tree).
 

--- a/README.md
+++ b/README.md
@@ -533,7 +533,9 @@ an object with two properties:
      used because its possible one custom id is represented multiple times in the tree).
 
 ```javascript
-$('#tree').treeview('findNodesByCustomIds', [3, 4, 5])
+// we have to wrap the ids in an array because jQuery treats the arguments as an array
+// of individual arguments and the goal is to pass an entire array
+$('#tree').treeview('findNodesByCustomIds', [[3, 4, 5]]);
 ```
 
 Triggers `findNodesByCustomIdsComplete` event.

--- a/README.md
+++ b/README.md
@@ -522,6 +522,22 @@ found then `undefined` is returned.
 $('#tree').treeview('findNodeIdByCustomId', 3)
 ```
 
+Triggers `findNodeIdByCustomIdComplete` event.
+
+#### findNodesByCustomIds(customIds)
+
+Find nodes in the tree whose `customId` matches those given in `customIds`. The return value is
+an object with two properties:
+  * `customIds` - the customIds given to the function
+  * `nodesMap` - an object that maps the customId to an array of matching tree nodes (an array is
+     used because its possible one custom id is represented multiple times in the tree).
+
+```javascript
+$('#tree').treeview('findNodesByCustomIds', [3, 4, 5])
+```
+
+Triggers `findNodesByCustomIdsComplete` event.
+
 #### getCollapsed()
 
 Returns an array of collapsed nodes e.g. state.expanded = false.

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -55,6 +55,7 @@
 		highlightSearchResults: true,
 		showBorder: true,
 		showIcon: true,
+                showLeafIconOnly: true,
 		showCheckbox: false,
 		showTags: false,
 		multiSelect: false,
@@ -528,28 +529,37 @@
 
 			// Add expand, collapse or empty spacer icons
 			var classList = [];
-			if (node.nodes) {
+			if (node.nodes && node.nodes.length > 0) {
 				classList.push('expand-icon');
 				if (node.state.expanded) {
-					classList.push(_this.options.collapseIcon);
+					classList.push(node.collapseIcon || _this.options.collapseIcon);
 				}
 				else {
-					classList.push(_this.options.expandIcon);
+					classList.push(node.expandIcon || _this.options.expandIcon);
 				}
 			}
 			else {
 				classList.push(_this.options.emptyIcon);
 			}
 
-			treeItem
-				.append($(_this.template.icon)
-					.addClass(classList.join(' '))
-				);
-
+			// only add the 'icon' template if it's not a leaf node
+			if (node.nodes && node.nodes.length > 0) {
+				treeItem
+					.append($(_this.template.icon)
+						.addClass(classList.join(' '))
+					);
+			}
 
 			// Add node icon
-			if (_this.options.showIcon && !node.nodes) {
-				
+			var displayIcon = false;
+			if (_this.options.showLeafIconOnly) {
+				if (!node.nodes || node.nodes.length == 0) {
+					displayIcon = true;
+				}
+			} else if (_this.options.showIcon) {
+				displayIcon = true;
+			}
+			if (displayIcon) {
 				var classList = ['node-icon'];
 
 				classList.push(node.icon || _this.options.nodeIcon);

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -1184,7 +1184,7 @@
 	    this.nodes.forEach(function(node) {
               if (node.customId == customId) {
                 return node.nodeId;
-              {
+              }
             });
             return undefined;
         };

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -70,7 +70,8 @@
 		onNodeUnchecked: undefined,
 		onNodeUnselected: undefined,
 		onSearchComplete: undefined,
-		onSearchCleared: undefined
+		onSearchCleared: undefined,
+                onFindNodeIdByCustomIdComplete: undefined
 	};
 
 	_default.options = {
@@ -249,6 +250,10 @@
 		if (typeof (this.options.onSearchCleared) === 'function') {
 			this.$element.on('searchCleared', this.options.onSearchCleared);
 		}
+
+                if (typeof (this.options.onFindNodeIdByCustomIdComplete) === 'function') {
+                        this.$element.on('findNodeIdByCustomIdComplete', this.options.onFindNodeIdByCustomIdComplete);
+                }
 	};
 
 	/*

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -15,6 +15,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * 
+ * Additional changes made in a fork located at:
+ * https://github.com/mindscratch/bootstrap-treeview
  * ========================================================= */
 
 ;(function ($, window, document, undefined) {
@@ -351,6 +354,12 @@
 
 			if (node.selectable) {
 				this.toggleSelectedState(node, _default.options);
+
+				// if a node is selected and it's not expanded, then expand it
+				// this allows clicking on a node label to expand it
+				if (!node.state.expanded) {
+					this.toggleExpandedState(node, _default.options);
+				}
 			} else {
 				this.toggleExpandedState(node, _default.options);
 			}

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -518,6 +518,7 @@
 				.addClass(node.state.selected ? 'node-selected' : '')
 				.addClass(node.searchResult ? 'search-result' : '') 
 				.attr('data-nodeid', node.nodeId)
+				.attr('data-custom-id', node.customId || '')
 				.attr('style', _this.buildStyleOverride(node));
 
 			// Add indent/spacer to mimic tree structure

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -547,7 +547,7 @@
 
 
 			// Add node icon
-			if (_this.options.showIcon) {
+			if (_this.options.showIcon && !node.nodes) {
 				
 				var classList = ['node-icon'];
 

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -1181,12 +1181,18 @@
           @return {number} the node id
         */
 	Tree.prototype.findNodeIdByCustomId = function(customId) {
-	    this.nodes.forEach(function(node) {
-              if (node.customId == customId) {
-                return node.nodeId;
-              }
-            });
-            return undefined;
+		var nodeId = undefined;
+		for (var i = 0; i < this.nodes.length; i++) {
+			if (this.nodes[i].customId == customId) {
+				nodeId = this.nodes[i].nodeId;
+				break;	
+			}
+		}
+
+		this.$element.trigger('findNodeIdByCustomIdComplete', {nodeId: nodeId, customId: customId}); 
+
+
+		return nodeId;
         };
 
 	/**

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -1210,16 +1210,17 @@
 	 *
 	 * Will fire the 'findNodesByCustomIdsComplete' event when complete. The
 	 * event handler will receive two parameters, the event and the results. The
-	 * results will be an object with two properties: customIds (the ids given
-	 * when performing the find operation) and nodesMap (an object that maps the
-	 * custom id to an array of matching tree node objects).
+	 * results will be an object with three properties: customIds (the ids given
+	 * when performing the find operation), nodeIds (an array of matching tree node ids),
+	 * and nodesMap (an object that maps the custom id to an array of matching tree node objects).
 	 *
    * @param {Number[]} customIds - the custom ids to search for
-   * @return {Object} - containing two parameters, 'customIds' and 'nodesMap'.
+   * @return {Object} - containing three parameters, 'customIds', 'nodeIds' and 'nodesMap'.
    */
 	Tree.prototype.findNodesByCustomIds = function(customIds) {
 		var nodesMap = {};
-		var result = {customIds: customIds, nodesMap: nodesMap;
+		var matchingNodeIds = [];
+		var result = {customIds: customIds, nodeIds: matchingNodeIds, nodesMap: nodesMap};
 
 		if (customIds == undefined || customIds.length == 0) {
 			this.$element.trigger('findNodesByCustomIdsComplete', result);
@@ -1237,6 +1238,7 @@
 					var matchingNodes = nodesMap[customId] || [];
 					matchingNodes.push(node);
 					nodesMap[customId] = matchingNodes;
+					matchingNodeIds.push(node.nodeId);
 					break;
 				}
 			}

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -143,7 +143,9 @@
 
 			// Search methods
 			search: $.proxy(this.search, this),
-			clearSearch: $.proxy(this.clearSearch, this)
+			clearSearch: $.proxy(this.clearSearch, this),
+                       
+                        findNodeIdByCustomId: $.proxy(this.findNodeIdByCustomId, this)
 		};
 	};
 
@@ -1172,6 +1174,20 @@
 		
 		this.$element.trigger('searchCleared', $.extend(true, {}, results));
 	};
+
+        /**
+          Find the node that matches the given custom id.
+          @param {Number} customId - the customId property to find
+          @return {number} the node id
+        */
+	Tree.prototype.findNodeIdByCustomId = function(customId) {
+	    this.nodes.forEach(function(node) {
+              if (node.customId == customId) {
+                return node.nodeId;
+              {
+            });
+            return undefined;
+        };
 
 	/**
 		Find nodes that match a given criteria


### PR DESCRIPTION
When `showIcon` is true and a `nodeIcon` is defined, the `nodeIcon` shows up on every node. This pull request fixes it so the `nodeIcon` only shows up on leaf nodes.