### PR TITLE
Assign a specific selected color and a specific back color for each node

### DIFF
--- a/public/js/bootstrap-treeview.js
+++ b/public/js/bootstrap-treeview.js
@@ -627,7 +627,9 @@
 		var backColor = node.backColor;
 
 		if (this.options.highlightSelected && node.state.selected) {
-			if (this.options.selectedColor) {
+			if (node.selectedColor) {
+				color = node.selectedColor;
+			}else if (this.options.selectedColor) {
 				color = this.options.selectedColor;
 			}
 			if (node.selectedBackColor) {

--- a/public/js/bootstrap-treeview.js
+++ b/public/js/bootstrap-treeview.js
@@ -630,7 +630,9 @@
 			if (this.options.selectedColor) {
 				color = this.options.selectedColor;
 			}
-			if (this.options.selectedBackColor) {
+			if (node.selectedBackColor) {
+				backColor = node.selectedBackColor;
+			} else if (this.options.selectedBackColor) {
 				backColor = this.options.selectedBackColor;
 			}
 		}


### PR DESCRIPTION
We can not only set a selected color and a selected background color for the whole tree, but also set different selected colors and different selected background colors for each node. By adding the attribute "selectedColor", and "selectedBackColor" for each node when building them.
Usage : 
```
        var tree = [
            {
                text: "Parent 1",
                selectedColor: '#FFFFFF',
                selectedBackColor: '#67a74d',
                nodes: [
                    {
                        text: "Child 1",
                        nodes: [
                            {
                                text: "Grandchild 1",
                                selectedColor: '#FFFFFF',
                                selectedBackColor: '#67a74d'
                            }
                        ]
                    }
                ]
            }
        ]
```