### PR TITLE
template becomes configurable, hide link if no href

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -41,6 +41,8 @@
 		checkedIcon: 'glyphicon glyphicon-check',
 		uncheckedIcon: 'glyphicon glyphicon-unchecked',
 
+		template: {},
+
 		color: undefined, // '#000000',
 		backColor: undefined, // '#FFFFFF',
 		borderColor: undefined, // '#dddddd',
@@ -159,6 +161,7 @@
 			delete options.data;
 		}
 		this.options = $.extend({}, _default.settings, options);
+		this.template = $.extend(this.template, this.options.template);
 
 		this.destroy();
 		this.subscribeEvents();
@@ -582,7 +585,7 @@
 			}
 
 			// Add text
-			if (_this.options.enableLinks) {
+			if (_this.options.enableLinks && node.href) {
 				// Add hyperlink
 				treeItem
 					.append($(_this.template.link)


### PR DESCRIPTION
This enables the user to override the template, e.g. add _blank to link template.

Additionally, the link is hidden if links are enabled but no have has been configured, e.g. when only some nodes need to be a link,