### PR TITLE
Fixed dependency issues - fixes #334

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,26 +24,26 @@
     "dist/bootstrap-treeview.min.css"
   ],
   "scripts": {
-    "install": "bower install",
+    "install": "test -f bower.json && node_modules/bower/bin/bower install",
     "start": "node app",
-    "test": "grunt test"
+    "test": "node_modules/grunt-cli/bin/grunt test"
   },
   "engines": {
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "express": "3.4.x",
-    "ejs": "2.2.x",
-    "phantomjs": "1.9.x"
+    "bower": "1.3.x"
   },
   "devDependencies": {
-    "bower": "1.3.x",
+    "express": "3.4.x",
     "grunt": "0.4.x",
-    "grunt-contrib-uglify": "0.7.x",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-copy": "0.7.x",
     "grunt-contrib-cssmin": "0.12.x",
     "grunt-contrib-qunit": "0.5.x",
+    "grunt-contrib-uglify": "0.7.x",
     "grunt-contrib-watch": "0.6.x",
-    "grunt-contrib-copy": "0.7.x"
+    "phantomjs": "1.9.x"
   },
   "keywords": [
     "twitter",


### PR DESCRIPTION
- Moved development dependencies to the appropriate field in `package.json` to avoid installing unnecessary packages
- Removed useless `ejs` dependency
- Added `grunt-cli` dependency to be able to run tests without having Grunt installed on the local machine
- Edited `install` script to be able to install Bower dependencies without it installed on the local machine (and not run it at all if the package is installed as a dependency and not directly, because this simply does not make sense)