### PR TITLE
Keep node children on node update

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -1230,7 +1230,9 @@
 		targetNodes.splice(node.index, 1, newNode);
 
 		// remove old node from DOM
-		this._removeNodeEl(node);
+		if (node.$el !== newNode.$el) {
+			this._removeNodeEl(node);
+		}
 
 		// initialize new state and render changes
 		this._setInitialStates({nodes: this._tree}, 0)


### PR DESCRIPTION
If I try to edit a node from the `nodeSelected` event, the children get removed. This change is to keep children from being removed on that case.