### PR TITLE
Fix remove node

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -1195,10 +1195,10 @@
 			} else {
 				targetNodes = this._tree;
 			}
-			targetNodes.splice(node.index, 1);
+            var removedNodes = targetNodes.splice(node.index, 1);
 
 			// remove node from DOM
-			this._removeNodeEl(node);
+			this._removeNodeEl(removedNodes[0]);
 		}, this));
 
 		// initialize new state and render changes


### PR DESCRIPTION
If a node is specified but its children nodes are not present or not complete in the deleted node, `_removeNodeEl()` would fail. This fixes the issue by invoking the function on the nodes removed from splice.