### PR TITLE
Remove scripts from packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "dist/bootstrap-treeview.min.css"
   ],
   "scripts": {
-    "install": "bower install",
-    "start": "node app",
-    "test": "grunt test"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
The scripts are used for the example app only, when using it as a dependency it is not necessary to have it running automatically.