### PR TITLE
update copyrights to 2017 and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Jonathan Miles 
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -750,7 +750,8 @@ $('#tree').on('nodeSelected', function(event, data) {
 
 
 ## Copyright and Licensing
-Copyright 2013 Jonathan Miles
+
+Copyright 2017 Jonathan Miles
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/public/css/bootstrap-treeview.css
+++ b/public/css/bootstrap-treeview.css
@@ -1,7 +1,7 @@
 /* =========================================================
  * bootstrap-treeview.css v1.2.0
  * =========================================================
- * Copyright 2013 Jonathan Miles 
+ * Copyright 2017 Jonathan Miles 
  * Project URL : http://www.jondmiles.com/bootstrap-treeview
  *	
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/public/js/bootstrap-treeview.js
+++ b/public/js/bootstrap-treeview.js
@@ -1,7 +1,7 @@
 /* =========================================================
  * bootstrap-treeview.js v1.2.0
  * =========================================================
- * Copyright 2013 Jonathan Miles
+ * Copyright 2017 Jonathan Miles
  * Project URL : http://www.jondmiles.com/bootstrap-treeview
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/css/bootstrap-treeview.css
+++ b/src/css/bootstrap-treeview.css
@@ -1,7 +1,7 @@
 /* =========================================================
  * bootstrap-treeview.css v1.2.0
  * =========================================================
- * Copyright 2013 Jonathan Miles 
+ * Copyright 2017 Jonathan Miles 
  * Project URL : http://www.jondmiles.com/bootstrap-treeview
  *	
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -1,7 +1,7 @@
 /* =========================================================
  * bootstrap-treeview.js v1.2.0
  * =========================================================
- * Copyright 2013 Jonathan Miles
+ * Copyright 2017 Jonathan Miles
  * Project URL : http://www.jondmiles.com/bootstrap-treeview
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/lib/bootstrap-treeview.css
+++ b/tests/lib/bootstrap-treeview.css
@@ -1,7 +1,7 @@
 /* =========================================================
  * bootstrap-treeview.css v1.2.0
  * =========================================================
- * Copyright 2013 Jonathan Miles 
+ * Copyright 2017 Jonathan Miles 
  * Project URL : http://www.jondmiles.com/bootstrap-treeview
  *	
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/lib/bootstrap-treeview.js
+++ b/tests/lib/bootstrap-treeview.js
@@ -1,7 +1,7 @@
 /* =========================================================
  * bootstrap-treeview.js v1.2.0
  * =========================================================
- * Copyright 2013 Jonathan Miles
+ * Copyright 2017 Jonathan Miles
  * Project URL : http://www.jondmiles.com/bootstrap-treeview
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- appears to be all locations, found with `grep -ri copyright .`
  from repo root

I'm vendoring your (SWEET!!!) library for a python library, when I noticed the `LICENSE` that I wanted to include in the copy didn't actually have a year / name.  I went ahead and found the other copyrights applicable and updated them to 2017 :smile:

Thanks for such a beautiful and flexible library!!!

P.S. See also #197 