### PR TITLE
Fix npm install for environments without bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,9 @@
       "url": "https://github.com/jonmiles/bootstrap-treeview/blob/master/LICENSE"
     }
   ],
-  "main": [
-    "dist/bootstrap-treeview.min.js",
-    "dist/bootstrap-treeview.min.css"
-  ],
+  "main": "dist/bootstrap-treeview.min.js",
   "scripts": {
-    "install": "bower install",
+    "dev-install": "bower install",
     "start": "node app",
     "test": "grunt test"
   },
@@ -44,6 +41,10 @@
     "grunt-contrib-qunit": "0.5.x",
     "grunt-contrib-watch": "0.6.x",
     "grunt-contrib-copy": "0.7.x"
+  },
+  "peerDependencies": {
+    "jquery": ">= 1.9.0",
+    "bootstrap": ">= 3.0.0"
   },
   "keywords": [
     "twitter",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-treeview",
   "description": "Tree View for Twitter Bootstrap",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/jonmiles/bootstrap-treeview",
   "author": {
     "name": "Jonathan Miles"


### PR DESCRIPTION
Renamed the "install" script to "dev-install" to avoid it being run after npm install and subsequently failing with: `npm ERR! bootstrap-treeview@1.2.0 install: "bower install"` if bower was not present. 
Added the bower dependencies to peerDependencies (jquery, bootstrap)